### PR TITLE
Add parameters "lanscape" and "letter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ PdfCreator.addEventListener("error", function(_evt){
 // Generate a PDF based on HTML
 PdfCreator.generatePDFWithHTML({
 	html : '<html><body><h1>Hello World!</h1></body></html>',
-	filename : 'hello.pdf'
+	filename : 'hello.pdf',
+	landscape: true, // print the document in horizontal (default is false => vertical)
+	letter: true // print the document with letter size (default is false => A4)
 });
 
 //Generate a PDF based on a webview

--- a/TestApp/app/assets/webview.html
+++ b/TestApp/app/assets/webview.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 	<title>My HTML</title>
-	<script type="text/javascript">
-		<!--
+	<!--script type="text/javascript">
 		Ti.App.addEventListener("app:webViewParse", parse);
 
 		// Function where the data will be parsed inside the HTML
@@ -30,11 +29,10 @@
 				Ti.App.fireEvent('app:webViewUpdated', paramError);
 			}
 		}
-		-->
-	</script>
+	</script-->
 </head>
 <body>
-	<h1>Customer Name: <span id="customer_name" /></h1>
+	<h1>Customer Name: <span id="customer_name"></span></h1>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis felis, pulvinar a semper sed, adipiscing id dolor. Pellentesque auctor nisi id magna consequat sagittis. Curabitur dapibus enim sit amet elit pharetra tincidunt feugiat nisl imperdiet. Ut convallis libero in urna ultrices accumsan. Donec sed odio eros. Donec viverra mi quis quam pulvinar at malesuada arcu rhoncus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est.</p>
 
 	<img src="" id="image" />

--- a/TestApp/app/controllers/index.js
+++ b/TestApp/app/controllers/index.js
@@ -47,7 +47,7 @@ PdfGeneration.generatePDFWithTemplate({
 
 PdfGeneration.generatePDFWithTemplate({
 	pdfFileName : 'pageBreakInside',
-	htmlFile : Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'pageBreakInside.html')
+	htmlFile : Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'pageBreakInside.html'),
 	successCallback : function (_data) {
 		console.log('SUCCESS!');
 		console.log('_data: ' + JSON.stringify(_data, null, '\t'));

--- a/android/src/com/propelics/pdfcreator/PdfcreatorModule.java
+++ b/android/src/com/propelics/pdfcreator/PdfcreatorModule.java
@@ -46,6 +46,7 @@ import com.itextpdf.text.Font;
 import com.itextpdf.text.FontFactory;
 import com.itextpdf.text.FontFactoryImp;
 import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.PdfWriter;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.tool.xml.XMLWorker;
@@ -105,6 +106,8 @@ public class PdfcreatorModule extends KrollModule
 		String html = "";
 		String author = "";
 		String filename = "";
+		Boolean landscape = Boolean.FALSE;
+		Boolean letter = Boolean.FALSE;
 		final float marginPt = 28.35f;//1cm == 28.35pt
 
 		try {
@@ -123,8 +126,26 @@ public class PdfcreatorModule extends KrollModule
 				Log.d(PROXY_NAME, "author: " + author);
 			}
 
+			if (args.containsKey("landscape")){
+				landscape = (Boolean) args.get("landscape");
+				Log.d(PROXY_NAME, "lanscape: " + landscape);
+			}
+
+			if (args.containsKey("letter")){
+				letter = (Boolean) args.get("letter");
+				Log.d(PROXY_NAME, "letter: " + letter);
+			}
+
+			Rectangle size = PageSize.A4;
+			if (letter){
+				size = PageSize.LETTER;
+			}
+			if (landscape){
+				size = size.rotate();
+			}
+
 			//create a new document
-			Document document = new Document(PageSize.LETTER, marginPt, marginPt, marginPt, 0);
+			Document document = new Document(size, marginPt, marginPt, marginPt, 0);
 			TiBaseFile file = TiFileFactory.createTitaniumFile(filename, true);
 			
 			// Parse to XHTML
@@ -143,7 +164,7 @@ public class PdfcreatorModule extends KrollModule
 			//document header attributes
 			document.addAuthor(author);
 			document.addCreationDate();
-			document.setPageSize(PageSize.LETTER);
+			document.setPageSize(size);
 			
 			//open document
 			document.open();
@@ -222,6 +243,8 @@ public class PdfcreatorModule extends KrollModule
 		String filename = "";
 		TiUIView webview = null;
 		int quality = 100;
+		Boolean landscape = Boolean.FALSE;
+		Boolean letter = Boolean.FALSE;
 
 		try {
 			if(args.containsKey("filename")){
@@ -239,19 +262,37 @@ public class PdfcreatorModule extends KrollModule
 				quality = TiConvert.toInt(args.get("quality"));
 			}
 
+			if (args.containsKey("landscape")){
+				landscape = (Boolean) args.get("landscape");
+				Log.d(PROXY_NAME, "lanscape: " + landscape);
+			}
+
+			if (args.containsKey("letter")){
+				letter = (Boolean) args.get("letter");
+				Log.d(PROXY_NAME, "letter: " + letter);
+			}
+
 			TiBaseFile file = TiFileFactory.createTitaniumFile(filename, true);
 			Log.d(PROXY_NAME, "file full path: " + file.nativePath());
 
-			OutputStream outputStream 	= file.getOutputStream();
+			Rectangle size = PageSize.A4;
+			if (letter){
+				size = PageSize.LETTER;
+			}
+			if (landscape){
+				size = size.rotate();
+			}
+
+			OutputStream outputStream = file.getOutputStream();
 			final int MARGIN = 0;
-			final float PDF_WIDTH = PageSize.LETTER.getWidth() - MARGIN * 2; // A4: 595 //Letter: 612
-			final float PDF_HEIGHT = PageSize.LETTER.getHeight() - MARGIN * 2; // A4: 842 //Letter: 792
+			final float PDF_WIDTH = size.getWidth() - MARGIN * 2; // A4: 595 //Letter: 612
+			final float PDF_HEIGHT = size.getHeight() - MARGIN * 2; // A4: 842 //Letter: 792
 			final int DEFAULT_VIEW_WIDTH = 980;
 			final int DEFAULT_VIEW_HEIGHT = 1384;
 			int viewWidth = DEFAULT_VIEW_WIDTH;
 			int viewHeight = DEFAULT_VIEW_HEIGHT;
 			
-			Document pdfDocument 	= new Document(PageSize.LETTER, MARGIN, MARGIN, MARGIN, MARGIN);
+			Document pdfDocument = new Document(size, MARGIN, MARGIN, MARGIN, MARGIN);
 			PdfWriter docWriter = PdfWriter.getInstance(pdfDocument, outputStream);
 
 			Log.d(PROXY_NAME, "PDF_WIDTH: " + PDF_WIDTH);
@@ -276,7 +317,7 @@ public class PdfcreatorModule extends KrollModule
 
 
 			} else {
-				Log.e(PROXY_NAME, "NO UI THREAD");				
+				Log.e(PROXY_NAME, "NO UI THREAD");
 				viewWidth = DEFAULT_VIEW_WIDTH;
 				viewHeight = DEFAULT_VIEW_HEIGHT;
 			}


### PR DESCRIPTION
I needed to print in horizontal (landscape), so I added this option.
I also changed the default size to A4, because it's the most common size used in printing, adding the "letter" parameter for printing optionally with that format.
Now parameters of your module are very similar to parameters of this one https://github.com/viezel/NappPDFCreator.

Note: I already added this feature more than one year ago, but the pull request is still open in the old repository.